### PR TITLE
Add functionality to read battery voltage

### DIFF
--- a/Software/cryologger_gvt/03_power.ino
+++ b/Software/cryologger_gvt/03_power.ino
@@ -1,10 +1,17 @@
-void readBattery()
+void readVoltage()
 {
   // Start loop timer
-  unsigned long loopStartTime = millis();
+  unsigned long loopStartTime = micros();
+
+  voltage = analogRead(A0); // Read voltage across a 150/100kOhm op-amp scaling circuit and 10/1 MOhm resistor divider
+  DEBUG_PRINT("ADC: "); DEBUG_PRINTLN(voltage);
+  voltage /= 456.20; // Apply ADC linear gain
+  voltage += -0.1275; // Apply ADC linear offset
+  
+  DEBUG_PRINT("Battery voltage: "); DEBUG_PRINTLN(voltage);
 
   // Stop the loop timer
-  timer.battery = millis() - loopStartTime;
+  timer.voltage = micros() - loopStartTime;
 }
 
 // Enter deep sleep
@@ -30,10 +37,10 @@ void goToSleep()
   am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_UART0);
   am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_UART1);
 
-  // Disable all pads except G1 (33), G2 (34) and LED_BUILTIN (19)
+  // Disable all pads except G1 (33), G2 (34), A0 and LED_BUILTIN (19)
   for (int x = 0; x < 50; x++)
   {
-    if ((x != 33) && (x != 34) && (x != 19))
+    if ((x != 33) && (x != 34) && (x != A0) && (x != 19))
     {
       am_hal_gpio_pinconfig(x, g_AM_HAL_GPIO_DISABLE);
     }

--- a/Software/cryologger_gvt/05_gnss.ino
+++ b/Software/cryologger_gvt/05_gnss.ino
@@ -51,7 +51,7 @@ void configureGnss()
     /*
       // Configure communciation interfaces
       bool setValueSuccess = true;
-      //setValueSuccess &= gnss.newCfgValset8(UBLOX_CFG_I2C_ENABLED, 1);  // Disable I2C
+      setValueSuccess &= gnss.newCfgValset8(UBLOX_CFG_I2C_ENABLED, 1);  // Enable I2C
       setValueSuccess &= gnss.addCfgValset8(UBLOX_CFG_SPI_ENABLED, 0);    // Disable SPI
       setValueSuccess &= gnss.addCfgValset8(UBLOX_CFG_UART1_ENABLED, 0);  // Disable UART1
       setValueSuccess &= gnss.addCfgValset8(UBLOX_CFG_UART2_ENABLED, 0);  // Disable UART2
@@ -83,7 +83,6 @@ void configureGnss()
   gnss.setI2COutput(COM_TYPE_UBX);                  // Set the I2C port to output UBX only (disable NMEA)
   gnss.saveConfigSelective(VAL_CFG_SUBSEC_IOPORT);  // Save communications port settings to flash and BBR
   gnss.setNavigationFrequency(1);                   // Produce one navigation solution per second
-
   gnss.setAutoPVT(true);                            // Enable automatic NAV-PVT messages
   gnss.setAutoRXMSFRBX(true, false);                // Enable automatic RXM-SFRBX messages
   gnss.setAutoRXMRAWX(true, false);                 // Enable automatic RXM-RAWX messages
@@ -100,7 +99,7 @@ void syncRtc()
   // Start loop timer
   unsigned long loopStartTime = millis();
 
-  // Check u-blox GNSS initialized successfully
+  // Check if u-blox GNSS initialized successfully
   if (online.gnss)
   {
     // Clear flag
@@ -134,7 +133,7 @@ void syncRtc()
         DEBUG_PRINTLN(gnssBuffer);
 #endif
 
-        // Check if date and time are valid and sync RTC with GNSS
+        // Check if date and time are valid and synchronize RTC with GNSS
         if (fixType == 3 && dateValidFlag && timeValidFlag)
         {
           unsigned long rtcEpoch = rtc.getEpoch();        // Get RTC epoch time
@@ -157,9 +156,8 @@ void syncRtc()
   }
   else
   {
-    DEBUG_PRINTLN("Warning: microSD or GNSS offline!");
-    // Clear flag
-    rtcSyncFlag = false;
+    DEBUG_PRINTLN("Warning: GNSS offline!");
+    rtcSyncFlag = false; // Clear flag
   }
 
   // Stop the loop timer
@@ -169,7 +167,7 @@ void syncRtc()
 // Create timestamped log file name
 void getLogFileName()
 {
-  sprintf(logFileName, "GVMS1_20%02d%02d%02d_%02d%02d%02d.ubx",
+  sprintf(logFileName, "GVT_0_20%02d%02d%02d_%02d%02d%02d.ubx",
           rtc.year, rtc.month, rtc.dayOfMonth,
           rtc.hour, rtc.minute, rtc.seconds);
 }

--- a/Software/cryologger_gvt/06_debug.ino
+++ b/Software/cryologger_gvt/06_debug.ino
@@ -16,8 +16,8 @@ void createDebugFile()
   }
 
   // Write header to file
-  debugFile.println("datetime,online_microSd,online_gnss,online_logGnss,online_logDebug,"
-                    "timer_microsd,timer_gnss,timer_syncRtc,timer_logGnss,timer_logDebug,"
+  debugFile.println("datetime,battery,online_microSd,online_gnss,online_logGnss,online_logDebug,"
+                    "timer_battery,timer_microsd,timer_gnss,timer_syncRtc,timer_logGnss,timer_logDebug,"
                     "rtcSyncFlag,rtcDrift,bytesWritten,maxBufferBytes,wdtCounterMax,"
                     "writeFailCounter,syncFailCounter,closeFailCounter,debugCounter");
 
@@ -67,10 +67,12 @@ void logDebug()
 
   // Log debugging information
   debugFile.print(dateTime);            debugFile.print(",");
+  debugFile.print(voltage);             debugFile.print(",");
   debugFile.print(online.microSd);      debugFile.print(",");
   debugFile.print(online.gnss);         debugFile.print(",");
   debugFile.print(online.logGnss);      debugFile.print(",");
   debugFile.print(online.logDebug);     debugFile.print(",");
+  debugFile.print(timer.voltage);       debugFile.print(",");
   debugFile.print(timer.microSd);       debugFile.print(",");
   debugFile.print(timer.gnss);          debugFile.print(",");
   debugFile.print(timer.syncRtc);       debugFile.print(",");
@@ -102,6 +104,37 @@ void logDebug()
     DEBUG_PRINTLN("Warning: Failed to close debug file.");
     closeFailCounter++; // Count number of failed file closes
   }
+
+  /*
+  DEBUG_PRINTLN("datetime,battery,online_microSd,online_gnss,online_logGnss,online_logDebug,"
+                    "timer_battery,timer_microsd,timer_gnss,timer_syncRtc,timer_logGnss,timer_logDebug,"
+                    "rtcSyncFlag,rtcDrift,bytesWritten,maxBufferBytes,wdtCounterMax,"
+                    "writeFailCounter,syncFailCounter,closeFailCounter,debugCounter");
+  */
+                   
+  // Print debugging information
+  DEBUG_PRINT(dateTime);          DEBUG_PRINT(",");
+  DEBUG_PRINT(voltage);           DEBUG_PRINT(",");
+  DEBUG_PRINT(online.microSd);    DEBUG_PRINT(",");
+  DEBUG_PRINT(online.gnss);       DEBUG_PRINT(",");
+  DEBUG_PRINT(online.logGnss);    DEBUG_PRINT(",");
+  DEBUG_PRINT(online.logDebug);   DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.voltage);     DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.microSd);     DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.gnss);        DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.syncRtc);     DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.logGnss);     DEBUG_PRINT(",");
+  DEBUG_PRINT(timer.logDebug);    DEBUG_PRINT(",");
+  DEBUG_PRINT(rtcSyncFlag);       DEBUG_PRINT(",");
+  DEBUG_PRINT(rtcDrift);          DEBUG_PRINT(",");
+  DEBUG_PRINT(bytesWritten);      DEBUG_PRINT(",");
+  DEBUG_PRINT(maxBufferBytes);    DEBUG_PRINT(",");
+  DEBUG_PRINT(wdtCounterMax);     DEBUG_PRINT(",");
+  DEBUG_PRINT(writeFailCounter);  DEBUG_PRINT(",");
+  DEBUG_PRINT(syncFailCounter);   DEBUG_PRINT(",");
+  DEBUG_PRINT(closeFailCounter);  DEBUG_PRINT(",");
+  DEBUG_PRINTLN(debugCounter);
+  
   // Stop the loop timer
   timer.logDebug = millis() - loopStartTime;
 }

--- a/Software/cryologger_gvt/09_print.ino
+++ b/Software/cryologger_gvt/09_print.ino
@@ -71,7 +71,7 @@ void printTimers()
   DEBUG_PRINT("readWdt: ");     printTab(1);  DEBUG_PRINTLN(timer.wdt);
   DEBUG_PRINT("readRtc: ");     printTab(1);  DEBUG_PRINTLN(timer.rtc);
   DEBUG_PRINT("microSD: ");     printTab(1);  DEBUG_PRINTLN(timer.microSd);
-  DEBUG_PRINT("battery: ");     printTab(1);  DEBUG_PRINTLN(timer.battery);
+  DEBUG_PRINT("voltage: ");     printTab(1);  DEBUG_PRINTLN(timer.voltage);
   DEBUG_PRINT("gnss: ");        printTab(2);  DEBUG_PRINTLN(timer.gnss);
   DEBUG_PRINT("syncRtc: ");     printTab(1);  DEBUG_PRINTLN(timer.syncRtc);
   DEBUG_PRINT("logDebug: ");    printTab(1);  DEBUG_PRINTLN(timer.logDebug);


### PR DESCRIPTION
Adds missing functionality to read battery voltage across a 10/1 MOhm resistor divider and 150/100kOhm op-amp scaling circuit. This entailed establishing a linear relationship of the analog measurements at various voltage inputs and using the offset and gain values to correct the voltage reading. This may require additional work to determine if all MicroMod Data Logging Carrier Boards have the same general offset and gain values.