### PR TITLE
Add OLED display and battery voltage measurement support

### DIFF
--- a/Software/Python/analog_readings.py
+++ b/Software/Python/analog_readings.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 31 20:40:22 2022
+
+@author: adam
+"""
+
+import seaborn as sns
+import matplotlib.pyplot as plt
+from scipy import stats
+from matplotlib.ticker import FormatStrFormatter
+
+df = pd.read_csv(
+    "/Users/adam/Downloads/correction.csv",
+    index_col=None,
+)
+
+slope, intercept, r_value, pv, se = stats.linregress(df['voltage'],df['adc'])
+ 
+fig, ax = plt.subplots(figsize=(10,6))
+sns.regplot(x="voltage", y="adc", data=df, ci=None, label="R2 = {0:.1f}".format(r_value)).legend(loc="best")
+#sns.despine()
+ax.xaxis.set_major_formatter(FormatStrFormatter('%.1f'))
+ax.set(xlabel='Voltage (V)', ylabel='ADC', )
+ax.grid(linestyle="dotted")
+plt.title("gain = 452.89 offset = -0.13")
+# Save figure
+fig.savefig("/Users/adam/Downloads/voltage.png", dpi=150, transparent=False, bbox_inches="tight")
+ 

--- a/Software/cryologger_gvt/01_rtc.ino
+++ b/Software/cryologger_gvt/01_rtc.ino
@@ -12,10 +12,7 @@ void setInitialAlarm()
   // 7: Alarm match hundredths                                      (every second)
 
   // Manually set the RTC date and time
-  //rtc.setTime(23, 57, 50, 0, 27, 3, 22); // hour, minutes, seconds, hundredths, day, month, year
-
-  // Get time before starting rolling alarm
-  //rtc.getTime();
+  //rtc.setTime(23, 58, 50, 0, 29, 3, 22); // hour, minutes, seconds, hundredths, day, month, year
 
   // Set initial alarm
   rtc.setAlarm(loggingStartTime, 0, 0, 0, 0, 0);
@@ -33,7 +30,7 @@ void setInitialAlarm()
   //rtc.clearInterrupt(); // Apollo3 Core v2.x
   am_hal_rtc_int_clear(AM_HAL_RTC_INT_ALM); // Apollo3 Core v1.x
 
-  // Set or clear alarm flag depending on logging mode
+  // Initial alarm flag is dependent on logging mode
   if (loggingMode == 3)
   {
     alarmFlag = true; // Set flag
@@ -62,8 +59,7 @@ void readRtc()
 // Set RTC alarm
 void setSleepAlarm()
 {
-  // Clear the RTC alarm interrupt
-  //rtc.clearInterrupt();
+  // Clear RTC alarm interrupt
   am_hal_rtc_int_clear(AM_HAL_RTC_INT_ALM);
 
   // Check for logging mode
@@ -94,7 +90,7 @@ void setSleepAlarm()
   }
   else if (loggingMode == 3)
   {
-    alarmFlag = true;
+    DEBUG_PRINTLN(F("Info: Continuous logging enabled"));
     return; // Skip setting alarm
   }
   else // What if none are set?
@@ -102,7 +98,7 @@ void setSleepAlarm()
     alarmFlag = true;
     return; // Skip setting alarm
   }
-  
+
   // Print the next RTC alarm date and time
   DEBUG_PRINT("Info: Current time "); getDateTime();
   DEBUG_PRINT("Info: Sleeping until "); printAlarm();
@@ -111,7 +107,6 @@ void setSleepAlarm()
 void setLoggingAlarm()
 {
   // Clear the RTC alarm interrupt
-  //rtc.clearInterrupt(); // Apollo3 Core v2.x
   am_hal_rtc_int_clear(AM_HAL_RTC_INT_ALM); // Apollo3 Core v1.x
 
   // Check for logging mode
@@ -144,8 +139,10 @@ void setLoggingAlarm()
     // Set daily RTC alarm
     rtc.setAlarm(0, 0, 0, 0, 0, 0); // hours, minutes, seconds, microseconds, day, month
 
+    //rtc.setAlarm((rtc.hour + loggingAlarmHours) % 24, (rtc.minute + loggingAlarmMinutes) % 60, 0, 0, rtc.dayOfMonth, rtc.month);
+
     // Set RTC alarm mode
-    rtc.setAlarmMode(loggingAlarmMode); // Alarm match at 00:00:00
+    rtc.setAlarmMode(loggingAlarmMode); // Alarm match hundredths, seconds, minute, hours (00:00:00 UTC)
 
     // Clear alarm flag
     alarmFlag = false;

--- a/Software/cryologger_gvt/01_rtc.ino
+++ b/Software/cryologger_gvt/01_rtc.ino
@@ -17,9 +17,6 @@ void setInitialAlarm()
   // Set initial alarm
   rtc.setAlarm(loggingStartTime, 0, 0, 0, 0, 0);
 
-  // Set initial rolling alarm
-  //rtc.setAlarm((rtc.hour + sleepAlarmHours) % 24, (rtc.minute + sleepAlarmMinutes) % 60, 0, 0, 0, 0);
-
   // Set the alarm mode
   rtc.setAlarmMode(initialAlarmMode);
 
@@ -41,7 +38,7 @@ void setInitialAlarm()
   }
 }
 
-// Read the real-time clock
+// Read the RTC
 void readRtc()
 {
   // Start the loop timer
@@ -93,17 +90,18 @@ void setSleepAlarm()
     DEBUG_PRINTLN(F("Info: Continuous logging enabled"));
     return; // Skip setting alarm
   }
-  else // What if none are set?
+  else 
   {
-    alarmFlag = true;
+    alarmFlag = true; // Default if no logging mode set
     return; // Skip setting alarm
   }
 
   // Print the next RTC alarm date and time
-  DEBUG_PRINT("Info: Current time "); getDateTime();
+  DEBUG_PRINT("Info: Current time "); printDateTime();
   DEBUG_PRINT("Info: Sleeping until "); printAlarm();
 }
 
+// Set logging duration alarm
 void setLoggingAlarm()
 {
   // Clear the RTC alarm interrupt
@@ -112,47 +110,37 @@ void setLoggingAlarm()
   // Check for logging mode
   if (loggingMode == 1)
   {
-    // Set daily alarm
+    // Set daily RTC alarm
     rtc.setAlarm(loggingStopTime, 0, 0, 0, 0, 0);
 
     // Set RTC alarm mode
     rtc.setAlarmMode(loggingAlarmMode); // Alarm match on hundredths, seconds,  minutes, hours
-
-    // Clear alarm flag
-    alarmFlag = false;
-
   }
   else if (loggingMode == 2)
   {
-    // Set rolling alarm
+    // Set rolling RTC alarm
     rtc.setAlarm((rtc.hour + loggingAlarmHours) % 24, (rtc.minute + loggingAlarmMinutes) % 60, 0, 0, rtc.dayOfMonth, rtc.month);
 
     // Set RTC alarm mode
-    rtc.setAlarmMode(loggingAlarmMode); // Alarm match on hundredths, seconds,  minutes
-
-    // Clear alarm flag
-    alarmFlag = false;
-
+    rtc.setAlarmMode(loggingAlarmMode);
   }
   else if (loggingMode == 3)
   {
-    // Set daily RTC alarm
+    // Set continuous RTC alarm
     rtc.setAlarm(0, 0, 0, 0, 0, 0); // hours, minutes, seconds, microseconds, day, month
 
-    //rtc.setAlarm((rtc.hour + loggingAlarmHours) % 24, (rtc.minute + loggingAlarmMinutes) % 60, 0, 0, rtc.dayOfMonth, rtc.month);
-
     // Set RTC alarm mode
-    rtc.setAlarmMode(loggingAlarmMode); // Alarm match hundredths, seconds, minute, hours (00:00:00 UTC)
-
-    // Clear alarm flag
-    alarmFlag = false;
+    rtc.setAlarmMode(4); // Alarm match hundredths, seconds, minute, hours (00:00:00 UTC)
   }
+
+  // Clear alarm flag
+  alarmFlag = false;
 
   // Print the next RTC alarm date and time
   DEBUG_PRINT("Info: Logging until "); printAlarm();
 }
 
-// Print the RTC's date and time
+// Get the RTC's date and time and store it in a buffer
 void getDateTime()
 {
   rtc.getTime(); // Get the RTC's date and time

--- a/Software/cryologger_gvt/01_rtc.ino
+++ b/Software/cryologger_gvt/01_rtc.ino
@@ -12,7 +12,7 @@ void setInitialAlarm()
   // 7: Alarm match hundredths                                      (every second)
 
   // Manually set the RTC date and time
-  rtc.setTime(23, 57, 50, 0, 27, 3, 22); // hour, minutes, seconds, hundredths, day, month, year
+  //rtc.setTime(23, 57, 50, 0, 27, 3, 22); // hour, minutes, seconds, hundredths, day, month, year
 
   // Get time before starting rolling alarm
   //rtc.getTime();

--- a/Software/cryologger_gvt/02_wdt.ino
+++ b/Software/cryologger_gvt/02_wdt.ino
@@ -1,32 +1,33 @@
-// Configure the Watchdog Timer
+// Configure the Watchdog Timer (WDT)
 void configureWdt()
 {
   /*
-    Simplified WDT Clock Divider Selections
-    WDT_OFF     = Low Power Mode. This setting disables the watch dog timer
+    Watchdog Timer (WDT) Clock Divider Selections
+    See: Apollo3 Blue Datasheet Section 15/Table 1002 for more information
+    WDT_OFF     = Low Power Mode. This setting disables the watchdog timer
     WDT_128HZ   = 28 Hz LFRC clock
     WDT_16HZ    = 16 Hz LFRC clock
     WDT_1HZ     = 1 Hz LFRC clock
     WDT_1_16HZ  = 1/16th Hz LFRC clock
   */
-  // Set the watchdog timer interrupt and reset periods
+  // Set the WDT interrupt and reset periods
   wdt.configure(WDT_16HZ, 128, 240); // 16 Hz clock, 10-second interrupt period, 15-second reset period
   //wdt.configure(WDT_1HZ, 64, 128); // 1 Hz clock, 64-second interrupt period, 128-second reset period
 
-  // Start the watchdog timer
+  // Start the WDT
   wdt.start();
 }
 
-// Reset the watchdog timer
+// Reset the WDT
 void petDog()
 {
   // Start the loop timer
   unsigned long loopStartTime = micros();
 
-  wdt.restart(); // Restart the watchdog timer
+  wdt.restart(); // Restart the WDT
   //DEBUG_PRINT("Watchdog interrupt: "); DEBUG_PRINTLN(wdtCounter);
-  wdtFlag = false; // Clear watchdog flag
-  wdtCounter = 0; // Reset watchdog interrupt counter
+  wdtFlag = false; // Clear WDT flag
+  wdtCounter = 0; // Reset WDT interrupt counter
 
   // Stop the loop timer
   timer.wdt = micros() - loopStartTime;

--- a/Software/cryologger_gvt/03_power.ino
+++ b/Software/cryologger_gvt/03_power.ino
@@ -4,7 +4,7 @@ float readVoltage()
   unsigned long loopStartTime = micros();
 
   // Measure voltage across 150/100 kOhm op-amp scaling circuit and 10/1 MOhm resistor divider
-  int reading = analogRead(A0);
+  reading = analogRead(A0);
   float voltage = reading / 453.23; // Apply ADC linear gain
   voltage += -0.1275; // Apply ADC linear offset
   //DEBUG_PRINT("ADC: "); DEBUG_PRINTLN(reading);
@@ -18,13 +18,13 @@ float readVoltage()
 // Enable internal I2C pull-ups to help communicate with I2C devices
 void enablePullups()
 {
-  Wire.setPullups(1); 
+  Wire.setPullups(1);
 }
 
 // Disable internal I2C pull-ups to help reduce bus errors
 void disablePullups()
 {
-  Wire.setPullups(0);       
+  Wire.setPullups(0);
 }
 
 // Enter deep sleep
@@ -42,6 +42,7 @@ void goToSleep()
 #if DEBUG
   Serial.end();         // Close Serial port
 #endif
+  disablePullups();     // Disable internal pull-ups to reduce leakage
   Wire.end();           // Disable I2C
   SPI.end();            // Disable SPI
   power_adc_disable();  // Disable ADC

--- a/Software/cryologger_gvt/03_power.ino
+++ b/Software/cryologger_gvt/03_power.ino
@@ -15,6 +15,18 @@ float readVoltage()
   timer.voltage = micros() - loopStartTime;
 }
 
+// Enable internal I2C pull-ups to help communicate with I2C devices
+void enablePullups()
+{
+  Wire.setPullups(1); 
+}
+
+// Disable internal I2C pull-ups to help reduce bus errors
+void disablePullups()
+{
+  Wire.setPullups(0);       
+}
+
 // Enter deep sleep
 void goToSleep()
 {
@@ -97,12 +109,13 @@ void wakeUp()
 
   ap3_adc_setup();        // Enable ADC
   Wire.begin();           // Enable I2C
-
   Wire.setClock(400000);  // Set I2C clock speed to 400 kHz
   SPI.begin();            // Enable SPI
+
 #if DEBUG
   Serial.begin(115200);   // Open Serial port
 #endif
+
 }
 
 // Enable power to Qwiic connector

--- a/Software/cryologger_gvt/03_power.ino
+++ b/Software/cryologger_gvt/03_power.ino
@@ -5,8 +5,8 @@ float readVoltage()
 
   // Measure voltage across 150/100 kOhm op-amp scaling circuit and 10/1 MOhm resistor divider
   reading = analogRead(A0);
-  float voltage = reading / 453.23; // Apply ADC linear gain
-  voltage += -0.1275; // Apply ADC linear offset
+  float voltage = reading / 452.89; // Apply ADC linear gain
+  voltage += -0.13; // Apply ADC linear offset
   //DEBUG_PRINT("ADC: "); DEBUG_PRINTLN(reading);
   //DEBUG_PRINT("Voltage: "); DEBUG_PRINTLN(voltage);
   return voltage;

--- a/Software/cryologger_gvt/04_microsd.ino
+++ b/Software/cryologger_gvt/04_microsd.ino
@@ -4,35 +4,55 @@ void configureSd()
   // Start loop timer
   unsigned long loopStartTime = millis();
 
-  // Initialize microSD
-  if (!sd.begin(PIN_SD_CS, SD_SCK_MHZ(24)))
+  // Check if microSD has been initialized
+  if (!online.microSd)
   {
-    DEBUG_PRINTLN("Warning: microSD failed to initialize. Reattempting...");
+    // Display OLED message
+    displayInitialize("microSD");
 
-    // Delay between initialization attempts
-    myDelay(2000);
-
+    // Initialize microSD
     if (!sd.begin(PIN_SD_CS, SD_SCK_MHZ(24)))
     {
-      DEBUG_PRINTLN("Warning: microSD failed to initialize.");
-      online.microSd = false;
-      while (1) 
+      DEBUG_PRINTLN("Warning: microSD failed to initialize. Reattempting...");
+
+      // Display OLED message
+      displayReattempt();
+
+      // Delay between initialization attempts
+      myDelay(2000);
+
+      if (!sd.begin(PIN_SD_CS, SD_SCK_MHZ(24)))
       {
-        // Force watchdog timer to reset system
-        blinkLed(2, 250);
-        delay(2000);
+        DEBUG_PRINTLN("Warning: microSD failed to initialize.");
+        online.microSd = false;
+
+        while (1)
+        {
+          // Force WDT to reset system
+          blinkLed(2, 250);
+          myDelay(2000);
+        }
+
+      }
+      else
+      {
+        online.microSd = true; // Set flag
+        DEBUG_PRINTLN("Info: microSD initialized.");
+        // Display OLED messages(s)
+        displaySuccess();
       }
     }
     else
     {
+      online.microSd = true; // Set flag
       DEBUG_PRINTLN("Info: microSD initialized.");
-      online.microSd = true;
+      // Display OLED messages(s)
+      displaySuccess();
     }
   }
   else
   {
-    DEBUG_PRINTLN("Info: microSD initialized.");
-    online.microSd = true;
+    return;
   }
   // Stop the loop timer
   timer.microSd = millis() - loopStartTime;

--- a/Software/cryologger_gvt/04_microsd.ino
+++ b/Software/cryologger_gvt/04_microsd.ino
@@ -26,13 +26,18 @@ void configureSd()
         DEBUG_PRINTLN("Warning: microSD failed to initialize.");
         online.microSd = false;
 
+        // Disable power to Qwiic connector
+        qwiicPowerOff();
+
+        // Disable power to peripherals
+        peripheralPowerOff();
+        
         while (1)
         {
           // Force WDT to reset system
           blinkLed(2, 250);
-          myDelay(2000);
+          delay(2000);
         }
-
       }
       else
       {
@@ -52,6 +57,7 @@ void configureSd()
   }
   else
   {
+    DEBUG_PRINTLN("Info: microSD already initialized.");
     return;
   }
   // Stop the loop timer

--- a/Software/cryologger_gvt/05_gnss.ino
+++ b/Software/cryologger_gvt/05_gnss.ino
@@ -7,8 +7,8 @@ void configureGnss()
   // Check if u-blox has been initialized
   if (!online.gnss)
   {
-    // Disable internal I2C pull-ups to help reduce bus errors
-    //Wire.setPullups(0);
+    // Disable internal I2C pull-ups
+    disablePullups();
 
     // Uncomment  line to enable GNSS debug messages on Serial
     //gnss.enableDebugging();
@@ -124,6 +124,9 @@ void syncRtc()
   // Check if u-blox GNSS initialized successfully
   if (online.gnss)
   {
+    // Disable internal I2C pull-ups
+    disablePullups();
+
     // Clear flag
     rtcSyncFlag = false;
 
@@ -224,6 +227,9 @@ void logGnss()
   // Check if microSD and u-blox GNSS initialized successfully
   if (online.microSd && online.gnss)
   {
+    // Disable internal I2C pull-ups
+    disablePullups();
+
     // Create a new log file and open for writing
     // O_CREAT  - Create the file if it does not exist
     // O_APPEND - Seek to the end of the file prior to each write
@@ -318,13 +324,14 @@ void logGnss()
         if (!screen)
         {
           screen = true;
+          //displayOn();
           displayScreen1();
         }
         else
         {
           screen = false;
-          //displayOff();
           displayScreen2();
+          //displayOff();
         }
 
         previousMillis = millis(); // Update previousMillis

--- a/Software/cryologger_gvt/06_debug.ino
+++ b/Software/cryologger_gvt/06_debug.ino
@@ -67,7 +67,7 @@ void logDebug()
 
   // Log debugging information
   debugFile.print(dateTime);            debugFile.print(",");
-  debugFile.print(voltage);             debugFile.print(",");
+  debugFile.print(readVoltage());       debugFile.print(",");
   debugFile.print(online.microSd);      debugFile.print(",");
   debugFile.print(online.gnss);         debugFile.print(",");
   debugFile.print(online.logGnss);      debugFile.print(",");
@@ -114,7 +114,7 @@ void logDebug()
                    
   // Print debugging information
   DEBUG_PRINT(dateTime);          DEBUG_PRINT(",");
-  DEBUG_PRINT(voltage);           DEBUG_PRINT(",");
+  DEBUG_PRINT(readVoltage());     DEBUG_PRINT(",");
   DEBUG_PRINT(online.microSd);    DEBUG_PRINT(",");
   DEBUG_PRINT(online.gnss);       DEBUG_PRINT(",");
   DEBUG_PRINT(online.logGnss);    DEBUG_PRINT(",");

--- a/Software/cryologger_gvt/07_display.ino
+++ b/Software/cryologger_gvt/07_display.ino
@@ -122,7 +122,6 @@ void displayRtcOffset(long drift)
     oled.print(drift);
     oled.display();
     disablePullups();
-    myDelay(4000);
   }
 }
 
@@ -180,7 +179,7 @@ void displayDeepSleep()
     oled.text(0, 0, "Entering deep sleep...");
     oled.display();
     disablePullups();
-    myDelay(2000);
+    myDelay(4000);
   }
 }
 

--- a/Software/cryologger_gvt/07_display.ino
+++ b/Software/cryologger_gvt/07_display.ino
@@ -1,6 +1,9 @@
 // Configure OLED display
 void configureOled()
 {
+  // Enable internal I2C pull-ups
+  enablePullups();
+
   // Initalize the OLED device and related graphics system
   if (!oled.begin())
   {
@@ -12,12 +15,24 @@ void configureOled()
     online.oled = true;
     DEBUG_PRINTLN("Info: OLED initialized");
   }
+
+  // Disable internal I2C pull-ups
+  disablePullups();
+}
+
+// Reset OLED display after sleep/power cycle
+void resetOled()
+{
+  online.oled = true;
+  enablePullups();
+  oled.reset();
 }
 
 void displayWelcome()
 {
   if (online.oled)
   {
+    enablePullups(); // Enable internal I2C pull-ups
     oled.erase();
     oled.text(0, 0, "Cryologger GVT");
     oled.text(0, 10, dateTimeBuffer);
@@ -26,7 +41,8 @@ void displayWelcome()
     oled.setCursor(54, 20);
     oled.print(readVoltage(), 2);
     oled.display();
-    myDelay(8000);
+    disablePullups();
+    myDelay(4000);
   }
 }
 
@@ -34,11 +50,13 @@ void displayInitialize(char *device)
 {
   if (online.oled)
   {
+    enablePullups();
     char displayBuffer[24];
     sprintf(displayBuffer, "Initializing %s...", device);
     oled.erase();
     oled.text(0, 0, displayBuffer);
     oled.display();
+    disablePullups();
   }
 }
 
@@ -46,8 +64,10 @@ void displaySuccess()
 {
   if (online.oled)
   {
+    enablePullups();
     oled.text(0, 10, "Success!");
     oled.display();
+    disablePullups();
     myDelay(2000);
   }
 }
@@ -56,8 +76,10 @@ void displayFailure()
 {
   if (online.oled)
   {
+    enablePullups(); // Enable internal I2C pull-ups
     oled.text(0, 10, "Failed!");
     oled.display();
+    disablePullups();
   }
 }
 
@@ -65,8 +87,10 @@ void displayReattempt()
 {
   if (online.oled)
   {
+    enablePullups();
     oled.text(0, 10, "Failed! Reattempting...");
     oled.display();
+    disablePullups();
   }
 }
 
@@ -74,9 +98,11 @@ void displayRtcSync()
 {
   if (online.oled)
   {
+    enablePullups();
     oled.erase();
     oled.text(0, 0, "Syncing RTC...");
     oled.display();
+    disablePullups();
   }
 }
 
@@ -95,6 +121,7 @@ void displayRtcOffset(long drift)
     oled.setCursor(66, 10);
     oled.print(drift);
     oled.display();
+    disablePullups();
     myDelay(4000);
   }
 }
@@ -103,6 +130,7 @@ void displayScreen1()
 {
   if (online.oled)
   {
+    enablePullups();
     char displayBuffer1[32];
     char displayBuffer2[32];
     sprintf(displayBuffer1, "File size: %d", (bytesWritten / 1024));
@@ -113,6 +141,7 @@ void displayScreen1()
     oled.text(0, 10, displayBuffer1);
     oled.text(0, 20, displayBuffer2);
     oled.display();
+    disablePullups();
   }
 }
 
@@ -123,6 +152,7 @@ void displayScreen2()
     // Get current date and time
     getDateTime();
 
+    enablePullups();
     oled.erase();
     oled.setCursor(0, 0);
     oled.print(dateTimeBuffer);
@@ -137,6 +167,7 @@ void displayScreen2()
     oled.setCursor(60, 20);
     oled.print((rtc.getEpoch() - logStartTime));
     oled.display();
+    disablePullups();
   }
 }
 
@@ -144,9 +175,11 @@ void displayDeepSleep()
 {
   if (online.oled)
   {
+    enablePullups();
     oled.erase();
     oled.text(0, 0, "Entering deep sleep...");
     oled.display();
+    disablePullups();
     myDelay(2000);
   }
 }
@@ -155,7 +188,14 @@ void displayOff()
 {
   if (online.oled)
   {
-    oled.erase();
-    oled.display();
+    oled.displayPower(1);
+  }
+}
+
+void displayOn()
+{
+  if (online.oled)
+  {
+    oled.displayPower(0);
   }
 }

--- a/Software/cryologger_gvt/07_display.ino
+++ b/Software/cryologger_gvt/07_display.ino
@@ -1,0 +1,161 @@
+// Configure OLED display
+void configureOled()
+{
+  // Initalize the OLED device and related graphics system
+  if (!oled.begin())
+  {
+    online.oled = false;
+    DEBUG_PRINTLN("Warning: OLED failed to initialize.");
+  }
+  else
+  {
+    online.oled = true;
+    DEBUG_PRINTLN("Info: OLED initialized");
+  }
+}
+
+void displayWelcome()
+{
+  if (online.oled)
+  {
+    oled.erase();
+    oled.text(0, 0, "Cryologger GVT");
+    oled.text(0, 10, dateTimeBuffer);
+    oled.setCursor(0, 20);
+    oled.print("Voltage:");
+    oled.setCursor(54, 20);
+    oled.print(readVoltage(), 2);
+    oled.display();
+    myDelay(8000);
+  }
+}
+
+void displayInitialize(char *device)
+{
+  if (online.oled)
+  {
+    char displayBuffer[24];
+    sprintf(displayBuffer, "Initializing %s...", device);
+    oled.erase();
+    oled.text(0, 0, displayBuffer);
+    oled.display();
+  }
+}
+
+void displaySuccess()
+{
+  if (online.oled)
+  {
+    oled.text(0, 10, "Success!");
+    oled.display();
+    myDelay(2000);
+  }
+}
+
+void displayFailure()
+{
+  if (online.oled)
+  {
+    oled.text(0, 10, "Failed!");
+    oled.display();
+  }
+}
+
+void displayReattempt()
+{
+  if (online.oled)
+  {
+    oled.text(0, 10, "Failed! Reattempting...");
+    oled.display();
+  }
+}
+
+void displayRtcSync()
+{
+  if (online.oled)
+  {
+    oled.erase();
+    oled.text(0, 0, "Syncing RTC...");
+    oled.display();
+  }
+}
+
+void displayRtcOffset(long drift)
+{
+  if (online.oled)
+  {
+    // Get current date and time
+    getDateTime();
+
+    oled.erase();
+    oled.setCursor(0, 0);
+    oled.print(dateTimeBuffer);
+    oled.setCursor(0, 10);
+    oled.print("RTC drift: ");
+    oled.setCursor(66, 10);
+    oled.print(drift);
+    oled.display();
+    myDelay(4000);
+  }
+}
+
+void displayScreen1()
+{
+  if (online.oled)
+  {
+    char displayBuffer1[32];
+    char displayBuffer2[32];
+    sprintf(displayBuffer1, "File size: %d", (bytesWritten / 1024));
+    sprintf(displayBuffer2, "Max buffer: %d", maxBufferBytes);
+
+    oled.erase();
+    oled.text(0, 0, logFileName);
+    oled.text(0, 10, displayBuffer1);
+    oled.text(0, 20, displayBuffer2);
+    oled.display();
+  }
+}
+
+void displayScreen2()
+{
+  if (online.oled)
+  {
+    // Get current date and time
+    getDateTime();
+
+    oled.erase();
+    oled.setCursor(0, 0);
+    oled.print(dateTimeBuffer);
+    oled.setCursor(0, 10);
+    oled.print("Voltage:");
+    oled.setCursor(54, 10);
+    oled.print(readVoltage(), 2);
+    oled.setCursor(90, 10);
+    oled.print(reading);
+    oled.setCursor(0, 20);
+    oled.print("Duration:");
+    oled.setCursor(60, 20);
+    oled.print((rtc.getEpoch() - logStartTime));
+    oled.display();
+  }
+}
+
+void displayDeepSleep()
+{
+  if (online.oled)
+  {
+    oled.erase();
+    oled.text(0, 0, "Entering deep sleep...");
+    oled.display();
+    myDelay(2000);
+  }
+}
+
+void displayOff()
+{
+  if (online.oled)
+  {
+    oled.erase();
+    oled.display();
+  }
+}

--- a/Software/cryologger_gvt/cryologger_gvt.ino
+++ b/Software/cryologger_gvt/cryologger_gvt.ino
@@ -75,19 +75,19 @@ SFE_UBLOX_GNSS    gnss;       // I2C address: 0x42
 // ----------------------------------------------------------------------------
 
 // Logging modes
-// 1: Daily logging period (e.g., log for 3 hours each day between 12:00-15:00)
-// 2: Rolling logging periods (e.g., log for 2 hours sleep for 3, repeat)
-// 3: 24-hours/day logging with new logfiles each day at 00:00
-byte          loggingMode           = 2;    // 1: daily, 2: rolling, 3: 24-hour
+// 1: Daily logging (e.g., 3 hours each day between 12:00-15:00)
+// 2: Rolling logging (e.g., 2 hours logging, 2 hours sleep for 3, repeat)
+// 3: Continuous logging (e.g., new logfiles created each day at 00:00)
+byte          loggingMode           = 3;    // 1: daily, 2: rolling, 3: 24-hour
 
 // Daily alarm
 byte          loggingStartTime      = 19;   // Logging start hour (UTC)
 byte          loggingStopTime       = 22;   // Logging end hour (UTC)
 
 // Rolling alarm
-byte          loggingAlarmMinutes   = 2;   // Rolling minutes alarm
-byte          loggingAlarmHours     = 0;    // Rolling hours alarm
-byte          sleepAlarmMinutes     = 1;    // Rolling minutes alarm
+byte          loggingAlarmMinutes   = 0;   // Rolling minutes alarm
+byte          loggingAlarmHours     = 1;    // Rolling hours alarm
+byte          sleepAlarmMinutes     = 0;    // Rolling minutes alarm
 byte          sleepAlarmHours       = 0;    // Rolling hours alarm
 
 // Manual alarm modes
@@ -117,10 +117,11 @@ unsigned long syncFailCounter     = 0;            // microSD logfile synchronize
 unsigned long writeFailCounter    = 0;            // microSD logfile write failure counter
 unsigned long closeFailCounter    = 0;            // microSD logfile close failure counter
 long          rtcDrift            = 0;            // Counter for drift of RTC
-//float         voltage             = 0.0;          // Battery voltage
 char          dateTimeBuffer[25];
 unsigned long logStartTime;
-int reading;
+int           reading;
+
+
 // ----------------------------------------------------------------------------
 // Unions/structures
 // ----------------------------------------------------------------------------
@@ -218,9 +219,9 @@ void loop()
     readRtc();            // Get the RTC's alarm date and time
     setLoggingAlarm();    // Set logging alarm
     getLogFileName();     // Get timestamped log file name
-
-    readVoltage();        // Read battery voltage
-    if(1)
+    
+    // Read battery voltage
+    if(readVoltage() < 10.0)
     {
       // To do: Add if statement to send system back to deep sleep if 
       // voltage is too low.
@@ -262,7 +263,6 @@ void loop()
 extern "C" void am_rtc_isr(void)
 {
   // Clear the RTC alarm interrupt
-  //rtc.clearInterrupt();
   am_hal_rtc_int_clear(AM_HAL_RTC_INT_ALM);
 
   // Set alarm flag

--- a/Software/cryologger_gvt/cryologger_gvt.ino
+++ b/Software/cryologger_gvt/cryologger_gvt.ino
@@ -1,6 +1,6 @@
 /*
     Title:    Cryologger - Glacier Velocity Tracker (GVT) v2.0.4
-    Date:     March 28, 2022
+    Date:     April 2, 2022
     Author:   Adam Garbo
 
     Components:
@@ -85,9 +85,9 @@ byte          loggingStartTime      = 19;   // Logging start hour (UTC)
 byte          loggingStopTime       = 22;   // Logging end hour (UTC)
 
 // Rolling alarm
-byte          loggingAlarmMinutes   = 0;   // Rolling minutes alarm
-byte          loggingAlarmHours     = 1;    // Rolling hours alarm
-byte          sleepAlarmMinutes     = 0;    // Rolling minutes alarm
+byte          loggingAlarmMinutes   = 30;   // Rolling minutes alarm
+byte          loggingAlarmHours     = 0;    // Rolling hours alarm
+byte          sleepAlarmMinutes     = 30;    // Rolling minutes alarm
 byte          sleepAlarmHours       = 0;    // Rolling hours alarm
 
 // Manual alarm modes
@@ -108,18 +108,18 @@ bool          gnssConfigFlag      = true;         // Flag to indicate whether to
 bool          rtcSyncFlag         = false;        // Flag to indicate if RTC has been synced with GNSS
 char          logFileName[30]     = "";           // Log file name
 char          debugFileName[20]   = "gvt_0_debug.csv";  // Debug log file name
+char          dateTimeBuffer[25];                 // Global buffer to store datetime information
 unsigned int  debugCounter        = 0;            // Counter to track number of recorded debug messages
-unsigned int  gnssTimeout         = 1;           // Timeout for GNSS signal acquisition (minutes)
+unsigned int  gnssTimeout         = 5;            // Timeout for GNSS signal acquisition (minutes)
 unsigned int  maxBufferBytes      = 0;            // Maximum value of file buffer
 unsigned long previousMillis      = 0;            // Global millis() timer
 unsigned long bytesWritten        = 0;            // Counter for tracking bytes written to microSD
 unsigned long syncFailCounter     = 0;            // microSD logfile synchronize failure counter
 unsigned long writeFailCounter    = 0;            // microSD logfile write failure counter
 unsigned long closeFailCounter    = 0;            // microSD logfile close failure counter
+unsigned long logStartTime        = 0;            // Global counter to track elapsed logging duration
 long          rtcDrift            = 0;            // Counter for drift of RTC
-char          dateTimeBuffer[25];
-unsigned long logStartTime;
-int           reading;
+int           reading             = 0;            // Battery voltage analog reading
 
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
**Major changes:**
- **OLED display**
  - Debugging and monitoring information can now be displayed on a SparkFun Qwiic OLED Display (SSD1306).
  - Note: This requires careful management of pull-up resistors to ensure that communication with the u-blox ZED-F9P is not affected.
- **Battery voltage measurement code**
  - 12 V battery voltage can now be measured using the onboard 10/1 MOhm resistor divider circuit.
  - This required that the circuit be characterized and specific offset and gain values calculated.
- **Continous (24-hour) logging mode**
  - The system can now be configured to immediately begin logging and create a new logfile daily at 00:00 UTC. 

**Minor changes:**
- Improved code commenting.
- `getDate()` function to update global char buffer without printing to Serial.
- In the event of a WDT-forced reset, both the Qwiic and microSD LDO regulators are turned off to help ensure the system will recover successfully.